### PR TITLE
Update reload-cert-with-import.sh for DSM7

### DIFF
--- a/reload-cert-with-import.sh
+++ b/reload-cert-with-import.sh
@@ -54,4 +54,9 @@ for domain_id in $(jq -r 'keys[]' $INFO); do
     fi
   done
 done
+# fix cert reload for DSM7
+if [ $exitcode -eq 1 ]; then
+  /usr/syno/bin/synow3tool --gen-all
+  synow3tool --restart-dsm-service
+fi
 exit $exitcode


### PR DESCRIPTION
Fix for DSM7 where certificates for web services are also copied to /usr/syno/etc/www/certificates/* by synow3tool